### PR TITLE
Extend question spoof to support new endpoint

### DIFF
--- a/Khanware.js
+++ b/Khanware.js
@@ -1,4 +1,4 @@
-const ver = "V3.2.8";
+const ver = "V3.2.9";
 let isDev = false;
 
 const repoPath = `https://raw.githubusercontent.com/Niximkk/Khanware/refs/heads/${isDev ? "dev/" : "main/"}`;


### PR DESCRIPTION
Updated question spoof logic to handle both 'getAssessmentItemById' and 'getAssessmentItemByProblemNumber' endpoints. Also bumped version to V3.2.9 in Khanware.js.