### PR TITLE
Update CDN references to use 'master' branch

### DIFF
--- a/Khanware.js
+++ b/Khanware.js
@@ -1,11 +1,11 @@
-const ver = "V3.3.0";
+const ver = "V3.3.1";
 let isDev = false;
 
 let repoPath;
 
 const availableCDNs = [
     `https://raw.githubusercontent.com/Niximkk/Khanware/refs/heads/${isDev ? "dev" : "main"}/`,
-    `https://cdn.jsdelivr.net/gh/niximkk/khanware@${isDev ? "dev" : "latest"}/`
+    `https://cdn.jsdelivr.net/gh/niximkk/khanware@${isDev ? "dev" : "master"}/`
 ];
 
 let device = {

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 🙂 Stable:
 ```js
-javascript:fetch("https://cdn.jsdelivr.net/gh/niximkk/khanware@latest/Khanware.js").then(t=>t.text()).then(eval);
+javascript:fetch("https://cdn.jsdelivr.net/gh/niximkk/khanware@master/Khanware.js").then(t=>t.text()).then(eval);
 ```
 🔧 Dev (beta):
 ```js
@@ -14,7 +14,7 @@ javascript:fetch("https://cdn.jsdelivr.net/gh/niximkk/khanware@dev/Khanware.js")
 ```
 🪶 Minimal (beta):
 ```js
-javascript:fetch("https://cdn.jsdelivr.net/gh/niximkk/khanware@latest/khanwareMinimal.js").then(t=>t.text()).then(eval);
+javascript:fetch("https://cdn.jsdelivr.net/gh/niximkk/khanware@master/khanwareMinimal.js").then(t=>t.text()).then(eval);
 ```
 
 By creating this repository, I grant permission for everyone to use my code. However, since it is licensed under the GPL, any modifications or distributions must also be open source.


### PR DESCRIPTION
Changed CDN URLs in Khanware.js and README.md to reference the 'master' branch instead of 'latest' for stable releases. Also bumped version to V3.3.1.